### PR TITLE
fix: replace rust emoji with hamster emoji for Pure Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for reader.Next() {
 
 | What You Get | How It Helps |
 |--------------|---------------|
-| 🦀 **Pure Go** | Easy deployment, no CGO complexity |
+| 🐹 **Pure Go** | Easy deployment, no CGO complexity |
 | ⚡ **Just-in-Time Metadata** | Fast connections, discover types on-demand |
 | 📊 **Streaming** | Constant memory usage, handles any result size |
 | 🎯 **Arrow Native** | Drop-in `array.RecordReader`, ecosystem ready |


### PR DESCRIPTION
## Problem

The README was using the rust emoji (🦀) for "Pure Go" which is incorrect - the crab emoji represents Rust, not Go.

## Solution

Replaced 🦀 with 🐹 (hamster) which better represents Go's gopher mascot family while maintaining the visual appeal and meaning.

## Changes

- `/README.md:22`: Changed `🦀 **Pure Go**` to `🐹 **Pure Go**`

## Context

This was discovered after adding branch protections, so a proper PR is needed for the fix.

Small but important correction to maintain consistency and accuracy in our documentation! 

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>