### PR TITLE
fix: update README to consistently show 17 supported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ While developed with rigorous quality processes, this software should be conside
 
 **✅ Ready for experimentation:**
 - Core functionality complete
-- 11 data types supported
+- 17 data types supported
 - Comprehensive test suite
 - Performance benchmarks
 
 **⚠️ Known limits:**
 - No parameterized queries (COPY protocol limitation)
 - Alpha quality - production validation needed
-- Limited to 11 PostgreSQL types (more coming)
+- Limited to 17 PostgreSQL types currently
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed inconsistency in README where supported types were listed as both 11 and 17
- Updated status section to consistently show 17 supported types  
- Changed "more coming" to "currently" for neutral phrasing about future type additions

## Test plan
- [x] Verified all mentions of type count are now consistent at 17
- [x] README still renders correctly

🤖 Generated with [Claude Code](https://claude.ai/code)