### PR TITLE
fix: correct Pool ownership behavior for NewPoolFromExisting

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1114,6 +1114,25 @@ func TestPoolOwnershipBehavior(t *testing.T) {
 		require.NoError(t, err)
 		pgxConn.Release()
 	})
+
+	t.Run("nil pool safety", func(t *testing.T) {
+		t.Parallel()
+		// Test that NewPoolFromExisting with nil doesn't panic on Close()
+		// This is defensive programming - while passing nil is a programmer error,
+		// Close() should not panic
+		pgarrowPool := pgarrow.NewPoolFromExisting(nil)
+
+		// This should not panic even though pool is nil
+		assert.NotPanics(t, func() {
+			pgarrowPool.Close()
+		}, "Close() should not panic even with nil pool")
+
+		// Multiple calls should also be safe
+		assert.NotPanics(t, func() {
+			pgarrowPool.Close()
+			pgarrowPool.Close()
+		}, "Multiple Close() calls should not panic with nil pool")
+	})
 }
 
 // TestTimestampTypesBasicIntegration tests basic timestamp functionality - DISABLED due to PostgreSQL type promotion

--- a/integration_test.go
+++ b/integration_test.go
@@ -1030,6 +1030,92 @@ func TestNewPoolFromExisting(t *testing.T) {
 	require.NoError(t, reader2.Err(), "count reader should not have errors")
 }
 
+// TestPoolOwnershipBehavior tests the Pool ownership behavior between NewPool and NewPoolFromExisting
+func TestPoolOwnershipBehavior(t *testing.T) {
+	t.Parallel()
+
+	databaseURL := getTestDatabaseURL(t)
+	ctx := context.Background()
+
+	t.Run("NewPool owns underlying pgxpool", func(t *testing.T) {
+		t.Parallel()
+		// Create Pool using NewPool - it should own the underlying pgxpool
+		pool, err := pgarrow.NewPool(ctx, databaseURL)
+		require.NoError(t, err)
+
+		// Verify we can execute a query before closing
+		reader, err := pool.QueryArrow(ctx, "SELECT 1 as test")
+		require.NoError(t, err)
+		reader.Release()
+
+		// Close the pgarrow Pool - this should close the underlying pgxpool since it owns it
+		pool.Close()
+
+		// Attempting to use the pool after Close() should fail since the underlying pgxpool is closed
+		reader, err = pool.QueryArrow(ctx, "SELECT 1 as test")
+		require.Error(t, err, "should fail after Close() since underlying pgxpool is closed")
+		assert.Nil(t, reader)
+	})
+
+	t.Run("NewPoolFromExisting does not own underlying pgxpool", func(t *testing.T) {
+		t.Parallel()
+		// Create pgxpool directly
+		pgxPool, err := pgxpool.New(ctx, databaseURL)
+		require.NoError(t, err)
+		defer pgxPool.Close() // We manage this lifecycle
+
+		// Create pgarrow Pool from existing pgxpool - it should NOT own the underlying pgxpool
+		pgarrowPool := pgarrow.NewPoolFromExisting(pgxPool)
+
+		// Verify we can execute a query before calling Close()
+		reader, err := pgarrowPool.QueryArrow(ctx, "SELECT 1 as test")
+		require.NoError(t, err)
+		reader.Release()
+
+		// Call Close() on pgarrow Pool - this should be a no-op and NOT close the underlying pgxpool
+		pgarrowPool.Close()
+
+		// The underlying pgxpool should still be usable since pgarrowPool.Close() didn't close it
+		reader, err = pgarrowPool.QueryArrow(ctx, "SELECT 1 as test")
+		require.NoError(t, err, "should still work after pgarrowPool.Close() since underlying pgxpool is not closed")
+		reader.Release()
+
+		// Verify the pgxpool is still functional directly
+		pgxConn, err := pgxPool.Acquire(ctx)
+		require.NoError(t, err, "pgxpool should still be functional")
+		pgxConn.Release()
+	})
+
+	t.Run("multiple Close calls are safe", func(t *testing.T) {
+		t.Parallel()
+		// Test NewPool case
+		pool, err := pgarrow.NewPool(ctx, databaseURL)
+		require.NoError(t, err)
+
+		// Multiple Close() calls should be safe
+		pool.Close()
+		pool.Close() // Should not panic or error
+		pool.Close() // Should not panic or error
+
+		// Test NewPoolFromExisting case
+		pgxPool, err := pgxpool.New(ctx, databaseURL)
+		require.NoError(t, err)
+		defer pgxPool.Close()
+
+		pgarrowPool := pgarrow.NewPoolFromExisting(pgxPool)
+
+		// Multiple Close() calls should be safe (and no-ops)
+		pgarrowPool.Close()
+		pgarrowPool.Close() // Should not panic or error
+		pgarrowPool.Close() // Should not panic or error
+
+		// Verify pgxpool is still functional
+		pgxConn, err := pgxPool.Acquire(ctx)
+		require.NoError(t, err)
+		pgxConn.Release()
+	})
+}
+
 // TestTimestampTypesBasicIntegration tests basic timestamp functionality - DISABLED due to PostgreSQL type promotion
 func TestTimestampTypesIntegration(t *testing.T) {
 	t.Parallel()

--- a/pgarrow.go
+++ b/pgarrow.go
@@ -210,7 +210,7 @@ func (p *Pool) executeCopyAndParse(ctx context.Context, conn *pgxpool.Conn, sql 
 //	}
 //	defer pool.Close()
 func (p *Pool) Close() {
-	if p.isOwner {
+	if p.isOwner && p.pool != nil {
 		p.pool.Close()
 	}
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes critical documentation/implementation contradiction in Pool ownership behavior:
- `NewPoolFromExisting` documentation promised it wouldn't close the underlying pgxpool 
- But `Close()` implementation always closed the underlying pool regardless of creation method
- This could cause unexpected shutdowns in applications sharing pgx pools

## Changes Made

- **Add ownership tracking**: `isOwner bool` field to Pool struct
- **Fix constructors**: 
  - `NewPool` sets `isOwner: true` (creates and owns the pgxpool)
  - `NewPoolFromExisting` sets `isOwner: false` (receives existing pgxpool)
- **Fix Close() behavior**: Only closes underlying pgxpool if `isOwner` is true
- **Update documentation**: Clear explanation of ownership semantics
- **Add comprehensive tests**: `TestPoolOwnershipBehavior` covering all scenarios

## Test Plan

- [x] Added `TestPoolOwnershipBehavior` with 3 test scenarios:
  - `NewPool` ownership behavior verification
  - `NewPoolFromExisting` non-ownership behavior verification
  - Multiple Close() calls safety verification
- [x] All existing tests pass
- [x] `make validate` passes with 0 issues
- [x] Backward compatibility maintained

## Impact

- **API Safety**: `NewPoolFromExisting` now behaves exactly as documented
- **Shared Pool Support**: Applications can safely share pgx pools between transactional and analytical workloads
- **Backward Compatible**: Existing `NewPool` usage unchanged
- **Defensive Programming**: Multiple Close() calls are safe

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)