### PR TITLE
Refactor: Implement Options Pattern for Pool Constructors

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,14 +27,12 @@ go run main.go
 
 ### 2. Types Example (`types/`)
 
-Comprehensive demonstration of all 7 supported PostgreSQL data types:
-- `bool` (PostgreSQL OID 16)
-- `int2/smallint` (PostgreSQL OID 21) 
-- `int4/integer` (PostgreSQL OID 23)
-- `int8/bigint` (PostgreSQL OID 20)
-- `float4/real` (PostgreSQL OID 700)
-- `float8/double precision` (PostgreSQL OID 701)
-- `text` (PostgreSQL OID 25)
+Comprehensive demonstration of all 17 supported PostgreSQL data types including:
+- `bool`, `bytea`
+- `int2/smallint`, `int4/integer`, `int8/bigint` 
+- `float4/real`, `float8/double precision`
+- `text`, `varchar`, `bpchar/char(n)`, `name`, `"char"`
+- `date`, `time`, `timestamp`, `timestamptz`, `interval`
 
 Also demonstrates:
 - NULL value handling

--- a/examples/types/main.go
+++ b/examples/types/main.go
@@ -44,7 +44,7 @@ func setupPool() *pgarrow.Pool {
 		}
 	}()
 
-	pool, err := pgarrow.NewPool(context.Background(), databaseURL)
+	pool, err := pgarrow.NewPool(context.Background(), databaseURL, pgarrow.WithAllocator(alloc))
 	if err != nil {
 		log.Fatalf("Failed to create pool: %v", err)
 	}

--- a/pgarrow_test.go
+++ b/pgarrow_test.go
@@ -171,7 +171,7 @@ func setupTestDBWithAllocator(t *testing.T, alloc memory.Allocator) (*pgarrow.Po
 	connStr := connConfig.ConnString()
 
 	// Create pgarrow Pool with the schema-specific connection and custom allocator
-	pool, err := pgarrow.NewPoolWithAllocator(context.Background(), connStr, alloc)
+	pool, err := pgarrow.NewPool(context.Background(), connStr, pgarrow.WithAllocator(alloc))
 	require.NoError(t, err, "should create pgarrow pool")
 
 	// Create test tables in the schema


### PR DESCRIPTION
## Summary
- Replace multiple constructor functions with elegant options pattern
- Single `NewPool(ctx, connString, ...opts)` function with `WithAllocator()` and `WithExistingPool()` options
- Maintains full backward compatibility for existing `NewPool(ctx, connString)` usage
- Updates all tests, examples, and documentation

## Benefits
- **Cleaner API**: Single constructor instead of 4 separate functions
- **More Extensible**: Easy to add new options without breaking changes  
- **Go Idiomatic**: Follows standard Go options pattern
- **Backward Compatible**: Existing code continues to work unchanged

## Changes
- `pgarrow.go`: New options pattern implementation
- `*_test.go`: Updated all test call sites to use new API
- `examples/types/main.go`: Fixed to actually use custom allocator
- `examples/README.md`: Updated to reflect 17 supported types (was incorrectly showing 7)

## Test Coverage
- All existing tests pass with new API
- Examples compile and work correctly
- `make validate` passes completely

## Migration Guide
```go
// Old API (still works)
pool, err := pgarrow.NewPool(ctx, connString)

// New options (replacement for old functions)
pool, err := pgarrow.NewPool(ctx, connString, pgarrow.WithAllocator(alloc))
pool, err := pgarrow.NewPool(ctx, "", pgarrow.WithExistingPool(pgxPool))
pool, err := pgarrow.NewPool(ctx, "", 
    pgarrow.WithExistingPool(pgxPool),
    pgarrow.WithAllocator(alloc))
```

🤖 Generated with [Claude Code](https://claude.ai/code)