### PR TITLE
feat(#94): Restore query parameterization support throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 Pure Go library that streams PostgreSQL query results directly to Arrow format using binary protocol. Designed for analytical workloads, data pipelines, and Arrow ecosystem integration.
 
 ```go
-// One pool, many queries - streaming results
-reader, err := pool.QueryArrow(ctx, "SELECT * FROM large_table")
+// One pool, many queries - with safe parameterization
+reader, err := pool.QueryArrow(ctx, 
+    "SELECT * FROM large_table WHERE created_at > $1",
+    time.Now().AddDate(0, -1, 0)) // Last month
 defer reader.Release()
 
 for reader.Next() {
@@ -27,6 +29,7 @@ for reader.Next() {
 | ⚡ **Just-in-Time Metadata** | Schema discovered at query time, not at connection time |
 | 📊 **Streaming** | Constant memory usage, handles any result size |
 | 🎯 **Arrow Native** | Drop-in `array.RecordReader`, ecosystem ready |
+| 🔒 **Safe Queries** | Full parameterization support prevents SQL injection |
 
 ## Quick Start
 
@@ -38,7 +41,11 @@ go get github.com/fwojciec/pgarrow
 ### 30-Second Example
 ```go
 pool, _ := pgarrow.NewPool(ctx, "postgres://...")
-reader, _ := pool.QueryArrow(ctx, "SELECT id, name FROM users")
+
+// Safe parameterized queries - no SQL injection
+reader, _ := pool.QueryArrow(ctx, 
+    "SELECT id, name FROM users WHERE active = $1 AND age > $2",
+    true, 18)
 defer reader.Release()
 
 for reader.Next() {

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,29 +53,35 @@ These examples work with any PostgreSQL database and don't require specific tabl
 - `VALUES` clauses to create inline data
 - PostgreSQL type casting (e.g., `123::int2`)
 
-## 📝 Literal SQL Design
+## 🔒 Safe Parameterized Queries
 
-PGArrow uses **literal SQL values** for optimal performance with the COPY BINARY protocol:
+PGArrow supports **full query parameterization** for safe, dynamic queries:
 
-✅ **Literal values approach:**
+✅ **Single parameter:**
 ```go
-// Use literal values directly in SQL for best performance
-record, err := pool.QueryArrow(ctx, "SELECT * FROM my_table WHERE id = 123")
+// Safe parameterized query - prevents SQL injection
+record, err := pool.QueryArrow(ctx, "SELECT * FROM my_table WHERE id = $1", 123)
 ```
 
-✅ **Multiple conditions:**
+✅ **Multiple parameters:**
 ```go
-// Build SQL with literal values
-record, err := pool.QueryArrow(ctx, "SELECT * FROM users WHERE id = 123 AND name = 'Alice'")
+// Multiple parameters with different types
+record, err := pool.QueryArrow(ctx, 
+    "SELECT * FROM users WHERE age > $1 AND name = $2", 
+    21, "Alice")
 ```
 
-✅ **Inline data generation:**
+✅ **Dynamic filtering:**
 ```go  
-// Use VALUES clauses for test data or small datasets
-record, err := pool.QueryArrow(ctx, "SELECT * FROM (VALUES (1, 'Alice'), (2, 'Bob')) AS my_table(id, name)")
+// Build dynamic queries safely
+minScore := 90.0
+active := true
+record, err := pool.QueryArrow(ctx, 
+    "SELECT * FROM users WHERE score >= $1 AND active = $2",
+    minScore, active)
 ```
 
-💡 **For dynamic queries with user input, use pgx directly with proper parameterization, then pass results to PGArrow if needed, or build SQL strings with proper escaping/validation.**
+💡 **Parameters are type-safe and prevent SQL injection. PostgreSQL handles type conversion based on the placeholder context.**
 
 ### Example DATABASE_URL formats:
 

--- a/select_parser.go
+++ b/select_parser.go
@@ -77,13 +77,13 @@ func NewSelectParser(conn *pgx.Conn, schema *arrow.Schema, alloc memory.Allocato
 
 // ParseAll executes the query and parses all results into a single Arrow record.
 // For large datasets, consider using StartParsing and ParseNextBatch for streaming.
-func (p *SelectParser) ParseAll(ctx context.Context, query string) (arrow.Record, error) {
+func (p *SelectParser) ParseAll(ctx context.Context, query string, args ...any) (arrow.Record, error) {
 	// Reset builders for new query
 	p.resetBuilders()
 	p.rowsProcessed = 0
 
 	// Execute query with binary protocol
-	rows, err := p.conn.Query(ctx, query)
+	rows, err := p.conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("executing query: %w", err)
 	}
@@ -105,13 +105,13 @@ func (p *SelectParser) ParseAll(ctx context.Context, query string) (arrow.Record
 }
 
 // StartParsing initiates query execution for streaming results
-func (p *SelectParser) StartParsing(ctx context.Context, query string) error {
+func (p *SelectParser) StartParsing(ctx context.Context, query string, args ...any) error {
 	if p.currentRows != nil {
 		return errors.New("parsing already in progress")
 	}
 
 	// Execute query with binary protocol
-	rows, err := p.conn.Query(ctx, query)
+	rows, err := p.conn.Query(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("executing query: %w", err)
 	}

--- a/select_record_reader.go
+++ b/select_record_reader.go
@@ -30,7 +30,7 @@ type SelectRecordReader struct {
 }
 
 // NewSelectRecordReader creates a streaming record reader using SELECT protocol
-func NewSelectRecordReader(ctx context.Context, conn *pgxpool.Conn, schema *arrow.Schema, query string, alloc memory.Allocator) (*SelectRecordReader, error) {
+func NewSelectRecordReader(ctx context.Context, conn *pgxpool.Conn, schema *arrow.Schema, query string, alloc memory.Allocator, args ...any) (*SelectRecordReader, error) {
 	// Ensure connection uses binary protocol for optimal performance
 	pgxConn := conn.Conn()
 
@@ -41,7 +41,7 @@ func NewSelectRecordReader(ctx context.Context, conn *pgxpool.Conn, schema *arro
 	}
 
 	// Start query execution eagerly to reduce latency on first Next()
-	if err := parser.StartParsing(ctx, query); err != nil {
+	if err := parser.StartParsing(ctx, query, args...); err != nil {
 		parser.Release()
 		return nil, fmt.Errorf("starting SELECT query: %w", err)
 	}


### PR DESCRIPTION
## Summary

This PR restores full query parameterization support now that we've switched from COPY to SELECT protocol with binary format. This removes a major limitation and enables safer, more flexible queries with SQL injection prevention.

Closes #94

## What Changed

### Core Interface Updates
- ✅ `QueryArrow` now accepts variadic args (`...any`) for query parameters
- ✅ Parameters flow through `SelectRecordReader` and `SelectParser` to pgx
- ✅ Type safety maintained for all supported Arrow types

### Test Refactoring
- ✅ All test queries now use parameters instead of string concatenation
- ✅ Test data values passed as parameters, not embedded in SQL strings
- ✅ Added parameterized queries to integration and benchmark tests
- ✅ Edge cases covered (NULL parameters handled correctly)

### Documentation & Examples
- ✅ Added comprehensive parameterized query demonstration in examples
- ✅ Updated README with parameterized query examples
- ✅ Removed all mentions of parameterization limitations
- ✅ Updated examples README to showcase safe parameterized queries

## Testing

All tests pass with full validation:
- ✅ `make validate` passes
- ✅ No SQL injection vulnerabilities
- ✅ Performance benchmarks show no regression
- ✅ Race detector passes

## Example Usage

```go
// Simple parameterized query
reader, err := pool.QueryArrow(ctx, 
    "SELECT * FROM users WHERE age > $1 AND active = $2",
    21, true)

// Multiple parameters with different types
reader, err := pool.QueryArrow(ctx,
    "SELECT * FROM orders WHERE created_at > $1 AND amount >= $2",
    time.Now().AddDate(0, -1, 0), 100.00)
```

## Implementation Notes

- The metadata discovery (`PREPARE` statement) doesn't need actual parameter values, only the query structure
- Parameters are passed directly to pgx's `Query()` method which handles all type conversion
- Backward compatible - non-parameterized queries still work
- No performance overhead from parameterization

## Checklist

- [x] Tests written and passing
- [x] Code follows patterns in CLAUDE.md
- [x] `make validate` passes
- [x] Documentation updated
- [x] Issue success criteria met
- [x] Examples demonstrate proper parameter usage

🤖 Generated with [Claude Code](https://claude.ai/code)