### PR TITLE
fix: correct investigation date to August 2025

### DIFF
--- a/docs/performance-investigation-2025.md
+++ b/docs/performance-investigation-2025.md
@@ -1,4 +1,4 @@
-# PostgreSQL to Arrow Performance Investigation - January 2025
+# PostgreSQL to Arrow Performance Investigation - August 2025
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary

Quick fix to correct the date in the performance investigation document header.

## Change

- Updated `docs/performance-investigation-2025.md` header from "January 2025" to "August 2025"

The investigation was actually conducted in August 2025, not January.

🤖 Generated with [Claude Code](https://claude.ai/code)